### PR TITLE
Add functionality to write train1 data to disk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,6 @@ WORKDIR /packet-test
 COPY --from=build /packet-test/server /packet-test/
 COPY --from=build /packet-test/generate-schema /packet-test/
 
-RUN /packet-test/generate-schema -pair1=/packet-test/pair1.json
+RUN /packet-test/generate-schema -pair1=/packet-test/pair1.json -train1=/packet-test/train1.json
 
 ENTRYPOINT ["./server"]

--- a/api/packet.go
+++ b/api/packet.go
@@ -4,9 +4,9 @@ import "time"
 
 // Packet represents the packet sent for network testing.
 type Packet struct {
-	Sequence  int    // Sequence number.
-	Timestamp int64  // Timestamp (sent).
-	Data      []byte // Data transmitted.
+	Sequence int    // ID.
+	Sent     int64  // Timestamp (sent).
+	Data     []byte // Data transmitted.
 }
 
 // Pair1Result represents the result of a Packet Pair test.
@@ -14,9 +14,27 @@ type Pair1Result struct {
 	Capacity float64 // Mbps
 }
 
-// Received encapsulates the structure received over the network.
+// Train1Result represents the result of the train1 test as written
+// to disk.
+type Train1Result struct {
+	Server       string
+	Client       string
+	StartTime    time.Time
+	EndTime      time.Time
+	Measurements []Measurement
+}
+
+// Received encapsulates the structure received over the network
 type Received struct {
-	*Packet
+	Sequence int
+	Sent     time.Time
 	Received time.Time
 	Size     int64
+}
+
+// Measurement represents a measurement result.
+type Measurement struct {
+	Packets    []*Received
+	Dispersion int64
+	Bandwidth  int64
 }

--- a/api/packet.go
+++ b/api/packet.go
@@ -19,8 +19,6 @@ type Pair1Result struct {
 type Train1Result struct {
 	Server       string
 	Client       string
-	StartTime    time.Time
-	EndTime      time.Time
 	Measurements []Measurement
 }
 
@@ -29,12 +27,16 @@ type Received struct {
 	Sequence int
 	Sent     time.Time
 	Received time.Time
-	Size     int64
+	Size     int64 // Bytes.
 }
 
 // Measurement represents a measurement result.
 type Measurement struct {
-	Packets    []*Received
-	Dispersion int64
-	Bandwidth  int64
+	Packets []*Received
+	Metrics
+}
+
+type Metrics struct {
+	Dispersion int64 // usecs.
+	Bandwidth  int64 // Mbps.
 }

--- a/api/packet.go
+++ b/api/packet.go
@@ -4,8 +4,8 @@ import "time"
 
 // Packet represents the packet sent for network testing.
 type Packet struct {
-	Sequence int    // ID.
-	Sent     int64  // Timestamp (sent).
+	Sequence int    // Sequence.
+	Sent     int64  // Sent timestamp.
 	Data     []byte // Data transmitted.
 }
 

--- a/cmd/generate-schema/schema.go
+++ b/cmd/generate-schema/schema.go
@@ -11,11 +11,13 @@ import (
 )
 
 var (
-	pair1Schema string
+	pair1Schema  string
+	train1Schema string
 )
 
 func init() {
 	flag.StringVar(&pair1Schema, "pair1", "/var/spool/datatypes/pair1.json", "Path to write the pair1 schema out to.")
+	flag.StringVar(&train1Schema, "train1", "/var/spool/datatypes/train1.json", "Path to write the train1 schema out to.")
 }
 
 func main() {
@@ -31,4 +33,15 @@ func main() {
 
 	err = os.WriteFile(pair1Schema, json, 0o644)
 	rtx.Must(err, "Failed to write pair1 schema")
+
+	train1Result := api.Train1Result{}
+	schema, err = bigquery.InferSchema(train1Result)
+	rtx.Must(err, "Failed to generate train1 schema")
+
+	schema = bqx.RemoveRequired(schema)
+	json, err = schema.ToJSONFields()
+	rtx.Must(err, "Failed to marshal train1 schema")
+
+	err = os.WriteFile(train1Schema, json, 0o644)
+	rtx.Must(err, "Failed to write train1 schema")
 }

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"net"
 
 	"github.com/m-lab/go/rtx"
@@ -10,6 +11,7 @@ import (
 
 var (
 	ctx, cancel = context.WithCancel(context.Background())
+	dataDir     = flag.String("datadir", "./data", "Path to write data out to.")
 )
 
 func main() {
@@ -20,7 +22,7 @@ func main() {
 	rtx.Must(err, "ListenUDP failed")
 	defer conn.Close()
 
-	h := handler.Client{}
+	h := handler.New(*dataDir)
 	go h.ProcessPacketLoop(conn)
 
 	<-ctx.Done()

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -12,9 +12,21 @@ import (
 var (
 	ctx, cancel = context.WithCancel(context.Background())
 	dataDir     = flag.String("datadir", "./data", "Path to write data out to.")
+	hostname    = flag.String("hostname", "localhost", "Server hostname.")
 )
 
 func main() {
+	flag.Parse()
+
+	// Set up TCP connection for results.
+	tcpAddr, err := net.ResolveTCPAddr("tcp", ":8080")
+	rtx.Must(err, "ResolveTCPAddr failed")
+
+	tcpConn, err := net.ListenTCP("tcp", tcpAddr)
+	rtx.Must(err, "ListenTCP")
+	defer tcpConn.Close()
+
+	// Set up UDP connection to run the test.
 	addr, err := net.ResolveUDPAddr("udp", ":1053")
 	rtx.Must(err, "ResolveUDPAddr failed")
 
@@ -22,8 +34,8 @@ func main() {
 	rtx.Must(err, "ListenUDP failed")
 	defer conn.Close()
 
-	h := handler.New(*dataDir)
-	go h.ProcessPacketLoop(conn)
+	h := handler.New(*dataDir, *hostname)
+	go h.ProcessPacketLoop(conn, tcpConn)
 
 	<-ctx.Done()
 	cancel()

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -2,19 +2,34 @@ package handler
 
 import (
 	"encoding/json"
+	"errors"
 	"net"
+	"os"
+	"path"
 	"time"
 
+	"github.com/m-lab/go/timex"
 	"github.com/m-lab/packet-test/api"
 	"github.com/m-lab/packet-test/static"
 	log "github.com/sirupsen/logrus"
 )
 
+var errNoData = errors.New("failed to receive measurement result")
+
 // Client handles requests for packet tests.
-type Client struct{}
+type Client struct {
+	dataDir string
+}
+
+// New returns a new instance of *Client.
+func New(dataDir string) *Client {
+	return &Client{
+		dataDir: dataDir,
+	}
+}
 
 // ProcessPacketLoop listens for a kickoff UDP packet and then runs a packet test.
-func (h *Client) ProcessPacketLoop(conn net.PacketConn) {
+func (c *Client) ProcessPacketLoop(conn net.PacketConn) {
 	log.Info("Listening for UDP packets")
 
 	buf := make([]byte, static.BufferBytes)
@@ -28,21 +43,60 @@ func (h *Client) ProcessPacketLoop(conn net.PacketConn) {
 		msg := string(buf[:n])
 		log.Infof("Received UDP packet addr: %s, n: %d, type: %s ", addr.String(), n, msg)
 
+		var result interface{}
+
 		switch msg {
 		case "pair1":
-			err = sendPairs(conn, addr)
+			err = c.sendPairs(conn, addr)
 		case "train1":
-			err = sendTrains(conn, addr)
+			result, err = c.sendTrains(conn, addr)
 		}
 
+		err = c.handleResult(conn, msg, err, result)
 		if err != nil {
 			log.Errorf("Failed %s test: %v", msg, err)
 		}
 	}
 }
 
+func (c *Client) handleResult(conn net.PacketConn, datatype string, err error, data interface{}) error {
+	if err != nil {
+		return err
+	}
+
+	if data == nil {
+		return errNoData
+	}
+
+	return c.writeMeasurements(conn, datatype, data)
+}
+
+func (c *Client) writeMeasurements(conn net.PacketConn, datatype string, data interface{}) error {
+	t := time.Now().UTC()
+	dir := path.Join(c.dataDir, datatype, t.Format(timex.YYYYMMDDWithSlash))
+	err := os.MkdirAll(dir, 0755)
+	if err != nil {
+		return err
+	}
+
+	filename := path.Join(dir, datatype+"-"+t.Format("20060102T150405.000000000Z")+".json")
+	file, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	jsonResult, err := json.Marshal(data)
+	if err != nil {
+		return nil
+	}
+
+	_, err = file.Write(jsonResult)
+	return err
+}
+
 func sendPacket(conn net.PacketConn, addr net.Addr, pkt *api.Packet) error {
-	pkt.Timestamp = time.Now().UTC().UnixMicro()
+	pkt.Sent = time.Now().UTC().UnixMicro()
 
 	m, err := json.Marshal(pkt)
 	if err != nil {

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -74,6 +74,7 @@ func (c *Client) handleResult(conn net.PacketConn, datatype string, err error, d
 func (c *Client) writeMeasurements(conn net.PacketConn, datatype string, data interface{}) error {
 	t := time.Now().UTC()
 	dir := path.Join(c.dataDir, datatype, t.Format(timex.YYYYMMDDWithSlash))
+	log.Info(dir)
 	err := os.MkdirAll(dir, 0755)
 	if err != nil {
 		return err

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -60,6 +60,7 @@ func (c *Client) ProcessPacketLoop(conn net.PacketConn) {
 }
 
 func (c *Client) handleResult(conn net.PacketConn, datatype string, err error, data interface{}) error {
+	log.Info(data)
 	if err != nil {
 		return err
 	}

--- a/handler/pair1.go
+++ b/handler/pair1.go
@@ -10,7 +10,7 @@ import (
 	"github.com/m-lab/packet-test/static"
 )
 
-func sendPairs(conn net.PacketConn, addr net.Addr) error {
+func (c *Client) sendPairs(conn net.PacketConn, addr net.Addr) error {
 	log.Info("Sending pairs")
 	pkt := &api.Packet{
 		Sequence: 0,

--- a/handler/train1.go
+++ b/handler/train1.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"encoding/json"
+	"math"
 	"net"
 	"time"
 
@@ -9,8 +11,14 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func sendTrains(conn net.PacketConn, addr net.Addr) error {
+func (c *Client) sendTrains(conn net.PacketConn, addr net.Addr) (*api.Train1Result, error) {
 	log.Info("Sending trains")
+
+	result := &api.Train1Result{
+		Server:    conn.LocalAddr().String(),
+		Client:    addr.String(),
+		StartTime: time.Now(),
+	}
 
 	for i := 0; i < static.TrainCount; i++ {
 		pkt := &api.Packet{
@@ -20,12 +28,42 @@ func sendTrains(conn net.PacketConn, addr net.Addr) error {
 		for j := 0; j < static.TrainLength; j++ {
 			err := sendPacket(conn, addr, pkt)
 			if err != nil {
-				return err
+				return nil, err
 			}
 		}
 		time.Sleep(static.TrainDelay)
 		pkt.Sequence++
 	}
 
-	return nil
+	measurements, err := receiveMeasurements(conn)
+	if err != nil {
+		return nil, err
+	}
+	result.Measurements = measurements
+	last := measurements[len(measurements)-1].Packets
+	result.EndTime = last[len(last)-1].Received
+
+	return result, nil
+}
+
+func receiveMeasurements(conn net.PacketConn) ([]api.Measurement, error) {
+	buf := make([]byte, math.MaxUint16)
+	measurements := make([]api.Measurement, static.TrainCount)
+
+	for i := 0; i < static.TrainCount; i++ {
+		n, _, err := conn.ReadFrom(buf)
+		if err != nil {
+			return nil, err
+		}
+
+		measurement := api.Measurement{}
+		err = json.Unmarshal(buf[:n], &measurement)
+		if err != nil {
+			return nil, err
+		}
+
+		measurements[i] = measurement
+	}
+
+	return measurements, nil
 }

--- a/handler/train1.go
+++ b/handler/train1.go
@@ -8,11 +8,10 @@ import (
 
 	"github.com/m-lab/packet-test/api"
 	"github.com/m-lab/packet-test/static"
-	log "github.com/sirupsen/logrus"
 )
 
 func (c *Client) sendTrains(conn net.PacketConn, addr net.Addr) (*api.Train1Result, error) {
-	log.Info("Sending trains")
+	// log.Info("Sending trains")
 
 	result := &api.Train1Result{
 		Server:    conn.LocalAddr().String(),


### PR DESCRIPTION
This PR adds functionality to write `train1` data out to disk and to autoloading.

- It sets up a TCP connection for the client to send the results to the server.
- It writes the results out to the local system in the server.
- It adds `train1` to the `generate-schema` command and generates the schema in the `Dockerfile`.

Autoloaded data can be found under `mlab-sandbox.raw_pt.train1`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-test/6)
<!-- Reviewable:end -->
