### PR TITLE
Add packet pair gap and write test data out

### DIFF
--- a/api/packet.go
+++ b/api/packet.go
@@ -4,14 +4,17 @@ import "time"
 
 // Packet represents the packet sent for network testing.
 type Packet struct {
-	Sequence int    // Sequence.
-	Sent     int64  // Sent timestamp.
-	Data     []byte // Data transmitted.
+	Sequence int           // Sequence.
+	Sent     int64         // Sent timestamp.
+	Gap      time.Duration // Probe gap.
+	Data     []byte        // Data transmitted.
 }
 
 // Pair1Result represents the result of a Packet Pair test.
 type Pair1Result struct {
-	Capacity float64 // Mbps
+	Server       string
+	Client       string
+	Measurements []Measurement
 }
 
 // Train1Result represents the result of the train1 test as written
@@ -27,6 +30,7 @@ type Received struct {
 	Sequence int
 	Sent     time.Time
 	Received time.Time
+	Gap      int64 // usecs.
 	Size     int64 // Bytes.
 }
 

--- a/api/packet.go
+++ b/api/packet.go
@@ -10,16 +10,8 @@ type Packet struct {
 	Data     []byte        // Data transmitted.
 }
 
-// Pair1Result represents the result of a Packet Pair test.
-type Pair1Result struct {
-	Server       string
-	Client       string
-	Measurements []Measurement
-}
-
-// Train1Result represents the result of the train1 test as written
-// to disk.
-type Train1Result struct {
+// Result represents the result of a packet test.
+type Result struct {
 	Server       string
 	Client       string
 	Measurements []Measurement

--- a/build.sh
+++ b/build.sh
@@ -3,4 +3,5 @@ set -ex
 
 go build -v ./cmd/server
 go build -v ./cmd/generate-schema
-go build -v ./cmd/client
+go build -v ./cmd/client/pair1
+go build -v ./cmd/client/train1

--- a/cmd/client/pair1/pair1.go
+++ b/cmd/client/pair1/pair1.go
@@ -39,7 +39,7 @@ func main() {
 		log.Errorf("Packet pair test failed: %v", err)
 	}
 
-	err = client.SendMeasurements(*server+":9990", datatype, measurements)
+	err = client.SendMeasurements(*server+":9998", datatype, measurements)
 	if err != nil {
 		log.Errorf("Failed to send measurements to server: %v", err)
 	}

--- a/cmd/client/pair1/pair1.go
+++ b/cmd/client/pair1/pair1.go
@@ -39,7 +39,7 @@ func main() {
 		log.Errorf("Packet pair test failed: %v", err)
 	}
 
-	err = client.SendMeasurements(*server+":8080", datatype, measurements)
+	err = client.SendMeasurements(*server+":9990", datatype, measurements)
 	if err != nil {
 		log.Errorf("Failed to send measurements to server: %v", err)
 	}

--- a/cmd/client/pair1/pair1.go
+++ b/cmd/client/pair1/pair1.go
@@ -13,19 +13,16 @@ import (
 	"github.com/m-lab/packet-test/static"
 )
 
+const (
+	datatype = "pair1"
+)
+
 var (
-	server = flag.String("server", "", "Server address")
+	server = flag.String("server", "localhost", "Server address")
 )
 
 func main() {
 	flag.Parse()
-
-	// Set up TCP connection for results.
-	tcpAddr, err := net.ResolveTCPAddr("tcp", *server+":8080")
-	rtx.Must(err, "Resolve TCPAddr failed")
-
-	tcpConn, err := net.DialTCP("tcp", nil, tcpAddr)
-	rtx.Must(err, "DialTCP failed")
 
 	// Set up UDP connection to run the test.
 	udpSocket, err := net.ResolveUDPAddr("udp", *server+":1053")
@@ -34,15 +31,15 @@ func main() {
 	conn, err := net.DialUDP("udp", nil, udpSocket)
 	rtx.Must(err, "DialUDP failed")
 
-	_, err = conn.Write([]byte("pair1"))
+	_, err = conn.Write([]byte(datatype))
 	rtx.Must(err, "Kickoff failed")
 
 	measurements, err := receivePairs(conn)
 	if err != nil {
-		log.Errorf("Packed pair test failed: %v", err)
+		log.Errorf("Packet pair test failed: %v", err)
 	}
 
-	err = client.SendMeasurements(tcpConn, measurements)
+	err = client.SendMeasurements(*server+":8080", datatype, measurements)
 	if err != nil {
 		log.Errorf("Failed to send measurements to server: %v", err)
 	}

--- a/cmd/client/pair1/pair1.go
+++ b/cmd/client/pair1/pair1.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"net"
+
+	"github.com/apex/log"
+	"github.com/m-lab/go/mathx"
+	"github.com/m-lab/go/rtx"
+	"github.com/m-lab/packet-test/api"
+	"github.com/m-lab/packet-test/pkg/client"
+	"github.com/m-lab/packet-test/static"
+)
+
+var (
+	server = flag.String("server", "", "Server address")
+)
+
+func main() {
+	flag.Parse()
+
+	// Set up TCP connection for results.
+	tcpAddr, err := net.ResolveTCPAddr("tcp", *server+":8080")
+	rtx.Must(err, "Resolve TCPAddr failed")
+
+	tcpConn, err := net.DialTCP("tcp", nil, tcpAddr)
+	rtx.Must(err, "DialTCP failed")
+
+	// Set up UDP connection to run the test.
+	udpSocket, err := net.ResolveUDPAddr("udp", *server+":1053")
+	rtx.Must(err, "ResolveUDPAddr failed")
+
+	conn, err := net.DialUDP("udp", nil, udpSocket)
+	rtx.Must(err, "DialUDP failed")
+
+	_, err = conn.Write([]byte("pair1"))
+	rtx.Must(err, "Kickoff failed")
+
+	measurements, err := receivePairs(conn)
+	if err != nil {
+		log.Errorf("Packed pair test failed: %v", err)
+	}
+
+	err = client.SendMeasurements(tcpConn, measurements)
+	if err != nil {
+		log.Errorf("Failed to send measurements to server: %v", err)
+	}
+}
+
+func receivePairs(conn *net.UDPConn) ([]api.Measurement, error) {
+	measurements := make([]api.Measurement, static.PairCount)
+	bw := make([]int64, static.PairCount)
+	var sum int64
+
+	for i := 0; i < static.PairCount; i++ {
+		pair, err := client.ReceiveTrain(conn, 2)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to receive packet pair: %v", err)
+		}
+
+		delta := client.GetDelta(pair[0].Received, pair[1].Received)
+		log.Infof("delta: %d usec", delta)
+		bw[i] = pair[1].Size * 8.0 / delta
+		log.Infof("bw: %d Mbps", bw[i])
+		sum += bw[i]
+
+		measurements[i] = api.Measurement{
+			Packets: pair,
+			Metrics: api.Metrics{
+				Dispersion: delta,
+				Bandwidth:  bw[i],
+			},
+		}
+	}
+
+	log.Infof("Bandwidth: %d Mbps", sum/static.PairCount)
+
+	return measurements, nil
+}
+
+func receiveTrains(conn *net.UDPConn) ([]api.Measurement, error) {
+	measurements := make([]api.Measurement, static.TrainCount)
+	bw := make([]int64, static.TrainCount)
+
+	for i := 0; i < static.TrainCount; i++ {
+		train, err := client.ReceiveTrain(conn, static.TrainLength)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to receive packet train: %v", err)
+		}
+
+		delta := client.GetDelta(train[1].Received, train[static.TrainLength-1].Received)
+		log.Infof("delta: %d usec", delta)
+		bw[i] = (train[1].Size << 3) * (static.TrainLength - 1) / delta
+		log.Infof("bw: %d Mbps", bw[i])
+
+		measurements[i] = api.Measurement{
+			Packets: train,
+			Metrics: api.Metrics{
+				Dispersion: delta,
+				Bandwidth:  bw[i],
+			},
+		}
+	}
+
+	mode, err := mathx.Mode(bw)
+	if err != nil {
+		return measurements, fmt.Errorf("Failed to calculate bandwidth: %v", err)
+	}
+	log.Infof("Bandwidth: %d Mbps", mode)
+
+	return measurements, nil
+}

--- a/cmd/client/train1/train1.go
+++ b/cmd/client/train1/train1.go
@@ -39,7 +39,7 @@ func main() {
 		log.Errorf("Packet train test failed: %v", err)
 	}
 
-	err = client.SendMeasurements(*server+":8080", datatype, measurements)
+	err = client.SendMeasurements(*server+":9990", datatype, measurements)
 	if err != nil {
 		log.Errorf("Failed to send measurements to server: %v", err)
 	}

--- a/cmd/client/train1/train1.go
+++ b/cmd/client/train1/train1.go
@@ -39,7 +39,7 @@ func main() {
 		log.Errorf("Packet train test failed: %v", err)
 	}
 
-	err = client.SendMeasurements(*server+":9990", datatype, measurements)
+	err = client.SendMeasurements(*server+":9998", datatype, measurements)
 	if err != nil {
 		log.Errorf("Failed to send measurements to server: %v", err)
 	}

--- a/cmd/client/train1/train1.go
+++ b/cmd/client/train1/train1.go
@@ -13,19 +13,16 @@ import (
 	"github.com/m-lab/packet-test/static"
 )
 
+const (
+	datatype = "train1"
+)
+
 var (
-	server = flag.String("server", "", "Server address")
+	server = flag.String("server", "localhost", "Server address")
 )
 
 func main() {
 	flag.Parse()
-
-	// Set up TCP connection for results.
-	tcpAddr, err := net.ResolveTCPAddr("tcp", *server+":8080")
-	rtx.Must(err, "Resolve TCPAddr failed")
-
-	tcpConn, err := net.DialTCP("tcp", nil, tcpAddr)
-	rtx.Must(err, "DialTCP failed")
 
 	// Set up UDP connection to run the test.
 	udpSocket, err := net.ResolveUDPAddr("udp", *server+":1053")
@@ -34,15 +31,15 @@ func main() {
 	conn, err := net.DialUDP("udp", nil, udpSocket)
 	rtx.Must(err, "DialUDP failed")
 
-	_, err = conn.Write([]byte("train1"))
+	_, err = conn.Write([]byte(datatype))
 	rtx.Must(err, "Kickoff failed")
 
 	measurements, err := receiveTrains(conn)
 	if err != nil {
-		log.Errorf("Packed train test failed: %v", err)
+		log.Errorf("Packet train test failed: %v", err)
 	}
 
-	err = client.SendMeasurements(tcpConn, measurements)
+	err = client.SendMeasurements(*server+":8080", datatype, measurements)
 	if err != nil {
 		log.Errorf("Failed to send measurements to server: %v", err)
 	}

--- a/cmd/generate-schema/schema.go
+++ b/cmd/generate-schema/schema.go
@@ -23,7 +23,7 @@ func init() {
 func main() {
 	flag.Parse()
 
-	pair1Result := api.Pair1Result{}
+	pair1Result := api.Result{}
 	schema, err := bigquery.InferSchema(pair1Result)
 	rtx.Must(err, "Failed to generate pair1 schema")
 
@@ -34,7 +34,7 @@ func main() {
 	err = os.WriteFile(pair1Schema, json, 0o644)
 	rtx.Must(err, "Failed to write pair1 schema")
 
-	train1Result := api.Train1Result{}
+	train1Result := api.Result{}
 	schema, err = bigquery.InferSchema(train1Result)
 	rtx.Must(err, "Failed to generate train1 schema")
 

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -36,7 +36,7 @@ func main() {
 	mux.HandleFunc("/v0/result", http.HandlerFunc(h.HandleResult))
 
 	srv := &http.Server{
-		Addr:    *hostname + ":9990",
+		Addr:    *hostname + ":9998",
 		Handler: mux,
 	}
 	rtx.Must(httpx.ListenAndServeAsync(srv), "Failed to start server")

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -36,7 +36,7 @@ func main() {
 	mux.HandleFunc("/v0/result", http.HandlerFunc(h.HandleResult))
 
 	srv := &http.Server{
-		Addr:    *hostname + ":9998",
+		Addr:    ":9998",
 		Handler: mux,
 	}
 	rtx.Must(httpx.ListenAndServeAsync(srv), "Failed to start server")

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -36,7 +36,7 @@ func main() {
 	mux.HandleFunc("/v0/result", http.HandlerFunc(h.HandleResult))
 
 	srv := &http.Server{
-		Addr:    *hostname + ":8080",
+		Addr:    *hostname + ":9990",
 		Handler: mux,
 	}
 	rtx.Must(httpx.ListenAndServeAsync(srv), "Failed to start server")

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"flag"
 	"net"
+	"net/http"
 
+	"github.com/m-lab/go/httpx"
 	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/packet-test/handler"
 )
@@ -18,14 +20,6 @@ var (
 func main() {
 	flag.Parse()
 
-	// Set up TCP connection for results.
-	tcpAddr, err := net.ResolveTCPAddr("tcp", ":8080")
-	rtx.Must(err, "ResolveTCPAddr failed")
-
-	tcpConn, err := net.ListenTCP("tcp", tcpAddr)
-	rtx.Must(err, "ListenTCP")
-	defer tcpConn.Close()
-
 	// Set up UDP connection to run the test.
 	addr, err := net.ResolveUDPAddr("udp", ":1053")
 	rtx.Must(err, "ResolveUDPAddr failed")
@@ -35,7 +29,18 @@ func main() {
 	defer conn.Close()
 
 	h := handler.New(*dataDir, *hostname)
-	go h.ProcessPacketLoop(conn, tcpConn)
+	go h.ProcessPacketLoop(conn)
+
+	// Set up result endpoint.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v0/result", http.HandlerFunc(h.HandleResult))
+
+	srv := &http.Server{
+		Addr:    *hostname + ":8080",
+		Handler: mux,
+	}
+	rtx.Must(httpx.ListenAndServeAsync(srv), "Failed to start server")
+	defer srv.Close()
 
 	<-ctx.Done()
 	cancel()

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/iam v1.1.7 // indirect
 	github.com/apache/arrow/go/v14 v14.0.2 // indirect
+	github.com/araddon/dateparse v0.0.0-20200409225146-d820a6159ab1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/apex/log v1.9.0/go.mod h1:m82fZlWIuiWzWP04XCTXmnX0xRkYYbCdYn8jbJeLBEA
 github.com/apex/logs v1.0.0/go.mod h1:XzxuLZ5myVHDy9SAmYpamKKRNApGj54PfYLcFrXqDwo=
 github.com/aphistic/golf v0.0.0-20180712155816-02c07f170c5a/go.mod h1:3NqKYiepwy8kCu4PNA+aP7WUV72eXWJeP9/r3/K9aLE=
 github.com/aphistic/sweet v0.2.0/go.mod h1:fWDlIh/isSE9n6EPsRmC0det+whmX6dJid3stzu0Xys=
+github.com/araddon/dateparse v0.0.0-20200409225146-d820a6159ab1 h1:TEBmxO80TM04L8IuMWk77SGL1HomBmKTdzdJLLWznxI=
+github.com/araddon/dateparse v0.0.0-20200409225146-d820a6159ab1/go.mod h1:SLqhdZcd+dF3TEVL2RMoob5bBP5R1P1qkox+HtCBgGI=
 github.com/aws/aws-sdk-go v1.20.6/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -96,6 +98,8 @@ github.com/googleapis/google-cloud-go-testing v0.0.0-20191008195207-8e1d251e947d
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7/go.mod h1:2iMrUgbbvHEiQClaW2NsSzMyGHqN+rDFqY705q49KG0=
+github.com/kabukky/httpscerts v0.0.0-20150320125433-617593d7dcb3 h1:Iy7Ifq2ysilWU4QlCx/97OoI4xT1IV7i8byT/EyIT/M=
+github.com/kabukky/httpscerts v0.0.0-20150320125433-617593d7dcb3/go.mod h1:BYpt4ufZiIGv2nXn4gMxnfKV306n3mWXgNu/d2TqdTU=
 github.com/klauspost/compress v1.16.7 h1:2mk3MPGNzKyxErAw8YaohYh69+pa4sIQSC0fPGCFR9I=
 github.com/klauspost/compress v1.16.7/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
 github.com/klauspost/cpuid/v2 v2.2.5 h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/qbZg=

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -31,7 +31,6 @@ func New(dataDir string, hostname string) *Client {
 }
 
 // ProcessPacketLoop listens for a kickoff UDP packet and then runs a packet test.
-// func (c *Client) ProcessPacketLoop(conn net.PacketConn, tcpConn *net.TCPListener) {
 func (c *Client) ProcessPacketLoop(conn net.PacketConn) {
 	log.Info("Listening for UDP packets")
 

--- a/handler/pair1.go
+++ b/handler/pair1.go
@@ -25,7 +25,7 @@ func (c *Client) sendPairs(conn net.PacketConn, addr net.Addr, gapIncr time.Dura
 			return err
 		}
 
-		time.Sleep(gapIncr)
+		time.Sleep(gap)
 		err = sendPacket(conn, addr, pkt)
 		if err != nil {
 			return err

--- a/handler/pair1.go
+++ b/handler/pair1.go
@@ -10,26 +10,31 @@ import (
 	"github.com/m-lab/packet-test/static"
 )
 
-func (c *Client) sendPairs(conn net.PacketConn, addr net.Addr) error {
+func (c *Client) sendPairs(conn net.PacketConn, addr net.Addr, gapIncr time.Duration) error {
 	log.Info("Sending pairs")
+
 	pkt := &api.Packet{
 		Sequence: 0,
 		Data:     make([]byte, static.PacketBytes),
 	}
 
+	var gap = 0 * time.Microsecond
 	for i := 0; i < static.PairCount; i++ {
 		err := sendPacket(conn, addr, pkt)
 		if err != nil {
 			return err
 		}
 
+		time.Sleep(gapIncr)
 		err = sendPacket(conn, addr, pkt)
 		if err != nil {
 			return err
 		}
 
-		time.Sleep(static.PairDelay)
 		pkt.Sequence++
+		gap += gapIncr
+		pkt.Gap = gap
+		time.Sleep(static.PairDelay)
 	}
 
 	return nil

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -16,6 +16,7 @@ func ReceiveTrain(conn *net.UDPConn, length int) ([]*api.Received, error) {
 	pkts := make([]*api.Received, 0)
 
 	for j := 0; j < length; j++ {
+		conn.SetReadDeadline(time.Now().Add(10 * time.Second))
 		n, err := conn.Read(buf)
 		if err != nil {
 			return nil, err

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,8 +1,11 @@
 package client
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
 	"net"
+	"net/http"
 	"time"
 
 	"github.com/m-lab/packet-test/api"
@@ -44,12 +47,13 @@ func GetDelta(first time.Time, last time.Time) int64 {
 		(last.UnixMicro() - first.UnixMicro())
 }
 
-func SendMeasurements(conn *net.TCPConn, measurements []api.Measurement) error {
+func SendMeasurements(addr string, datatype string, measurements []api.Measurement) error {
 	b, err := json.Marshal(measurements)
 	if err != nil {
 		return err
 	}
 
-	_, err = conn.Write(b)
+	url := fmt.Sprintf("http://%s/v0/result?datatype=%s", addr, datatype)
+	_, err = http.Post(url, "application/json", bytes.NewBuffer(b))
 	return err
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,0 +1,55 @@
+package client
+
+import (
+	"encoding/json"
+	"net"
+	"time"
+
+	"github.com/m-lab/packet-test/api"
+)
+
+func ReceiveTrain(conn *net.UDPConn, length int) ([]*api.Received, error) {
+	buf := make([]byte, 1024)
+	pkts := make([]*api.Received, 0)
+
+	for j := 0; j < length; j++ {
+		n, err := conn.Read(buf)
+		if err != nil {
+			return nil, err
+		}
+
+		var pkt = &api.Packet{}
+		err = json.Unmarshal(buf[:n], pkt)
+		if err != nil {
+			return nil, err
+		}
+
+		t := time.Now().UTC()
+		rcvd := &api.Received{
+			Sequence: pkt.Sequence,
+			Sent:     time.UnixMicro(pkt.Sent),
+			Received: t,
+			Gap:      pkt.Gap.Microseconds(),
+			Size:     int64(n),
+		}
+
+		pkts = append(pkts, rcvd)
+	}
+	return pkts, nil
+}
+
+// GetDelta computes the difference between two timestamps in microseconds.
+func GetDelta(first time.Time, last time.Time) int64 {
+	return (last.Unix()-first.Unix())*1000000 +
+		(last.UnixMicro() - first.UnixMicro())
+}
+
+func SendMeasurements(conn *net.TCPConn, measurements []api.Measurement) error {
+	b, err := json.Marshal(measurements)
+	if err != nil {
+		return err
+	}
+
+	_, err = conn.Write(b)
+	return err
+}

--- a/static/spec.go
+++ b/static/spec.go
@@ -5,9 +5,10 @@ import "time"
 // Constants used for packet testing.
 const (
 	BufferBytes = 508
-	PacketBytes = 726
+	PacketBytes = 720
 	PairCount   = 30
-	PairDelay   = 10000 * time.Microsecond
+	PairDelay   = 1 * time.Second
+	PairGap     = 10 * time.Microsecond
 	TrainCount  = 10
 	TrainDelay  = 1 * time.Second
 	TrainLength = 30


### PR DESCRIPTION
This PR adds the functionality to support a probe gap (increments of +=10usecs) for packet pair tests. 

It also enables writing `pair1` tests out and autoloading them. Sample data can be found under `mlab-sandbox.raw_pt.pair1`.

Apologies for not adding a proper README yet. I will most likely have more time to work on it after the retreat.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-test/7)
<!-- Reviewable:end -->
