### PR TITLE
Add script to run scheduled packet tests in sandbox

### DIFF
--- a/Dockerfile.schedule
+++ b/Dockerfile.schedule
@@ -1,0 +1,13 @@
+FROM golang:1.22-alpine AS build
+RUN apk add gcc git linux-headers musl-dev
+WORKDIR /packet-test-schedule
+
+COPY go.mod ./
+COPY go.sum ./
+RUN go mod download
+
+COPY ./ ./
+RUN go build -v ./cmd/client/pair1
+RUN go build -v ./cmd/client/train1
+
+ENTRYPOINT [ "./batch.sh" ]

--- a/batch.sh
+++ b/batch.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -ex
+
+while true; do
+    /packet-test-schedule/train1 -server pt-mlab1-lga0t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/train1 -server pt-mlab1-lga1t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/train1 -server pt-mlab2-lga0t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/train1 -server pt-mlab2-lga1t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/train1 -server pt-mlab3-lga0t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/train1 -server pt-mlab3-lga1t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/train1 -server pt-mlab4-lga0t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/train1 -server pt-mlab4-lga1t.mlab-sandbox.measurement-lab.org
+
+    /packet-test-schedule/pair1 -server pt-mlab1-lga0t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/pair1 -server pt-mlab1-lga1t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/pair1 -server pt-mlab2-lga0t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/pair1 -server pt-mlab2-lga1t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/pair1 -server pt-mlab3-lga0t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/pair1 -server pt-mlab3-lga1t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/pair1 -server pt-mlab4-lga0t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/pair1 -server pt-mlab4-lga1t.mlab-sandbox.measurement-lab.org
+
+    sleep 15m
+done


### PR DESCRIPTION
This PR adds a Docker file to run scheduled packet pair and packet train tests in sandbox.

The test results can be visualized [here](https://grafana.mlab-sandbox.measurementlab.net/d/d341c044-4e2c-4904-b05f-98e8bf1bbf32/packet-testing?orgId=1&from=now-7d&to=now).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-test/8)
<!-- Reviewable:end -->
