### PR TITLE
Make ndt7 data autoloadable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,6 @@ WORKDIR /packet-test
 COPY --from=build /packet-test/server /packet-test/
 COPY --from=build /packet-test/generate-schema /packet-test/
 
-RUN /packet-test/generate-schema -pair1=/packet-test/pair1.json -train1=/packet-test/train1.json
+RUN /packet-test/generate-schema -pair1=/packet-test/pair1.json -train1=/packet-test/train1.json -ndt7=/packet-test/ndt7.json
 
 ENTRYPOINT ["./server"]

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,12 @@
 #!/bin/sh
 set -ex
 
-go build -v ./cmd/server
+COMMIT=$(git log -1 --format=%h)
+versionflags="-X github.com/m-lab/go/prometheusx.GitShortCommit=${COMMIT}"
+
+go build -v \
+    -ldflags "$versionflags" \
+     ./cmd/server
 go build -v ./cmd/generate-schema
 go build -v ./cmd/client/pair1
 go build -v ./cmd/client/train1

--- a/cmd/generate-schema/schema.go
+++ b/cmd/generate-schema/schema.go
@@ -7,17 +7,20 @@ import (
 	"cloud.google.com/go/bigquery"
 	"github.com/m-lab/go/cloud/bqx"
 	"github.com/m-lab/go/rtx"
+	"github.com/m-lab/ndt-server/data"
 	"github.com/m-lab/packet-test/api"
 )
 
 var (
 	pair1Schema  string
 	train1Schema string
+	ndt7Schema   string
 )
 
 func init() {
 	flag.StringVar(&pair1Schema, "pair1", "/var/spool/datatypes/pair1.json", "Path to write the pair1 schema out to.")
 	flag.StringVar(&train1Schema, "train1", "/var/spool/datatypes/train1.json", "Path to write the train1 schema out to.")
+	flag.StringVar(&ndt7Schema, "ndt7", "/var/spool/datatypes/ndt7.json", "Path to write the ndt7 schema out to.")
 }
 
 func main() {
@@ -44,4 +47,15 @@ func main() {
 
 	err = os.WriteFile(train1Schema, json, 0o644)
 	rtx.Must(err, "Failed to write train1 schema")
+
+	ndt7Result := data.NDT7Result{}
+	schema, err = bigquery.InferSchema(ndt7Result)
+	rtx.Must(err, "Failed to generate ndt7 schema")
+
+	schema = bqx.RemoveRequired(schema)
+	json, err = schema.ToJSONFields()
+	rtx.Must(err, "Failed to marshal ndt7 schema")
+
+	err = os.WriteFile(ndt7Schema, json, 0o644)
+	rtx.Must(err, "Failed to write ndt7 schema")
 }


### PR DESCRIPTION
This PR makes the result of the ndt7 tests (and BBR-terminated ones) autoloadable.

Sample autoloaded data can be found under `mlab-sandbox.raw_pt.ndt7`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-test/10)
<!-- Reviewable:end -->
