### PR TITLE
Enable both early_exit and bbr_exit for same ndt7 test

### DIFF
--- a/handler/ndt7.go
+++ b/handler/ndt7.go
@@ -92,10 +92,10 @@ func getParams(values url.Values) (*sender.Params, error) {
 		switch name {
 		case static.EarlyExitParameterName:
 			bytes, _ := strconv.ParseInt(values[0], 10, 64)
-			params.IsEarlyExit = true
 			params.MaxBytes = bytes * 1000000 // Conver MB to bytes.
 		case static.BBRExitParameterName:
-			params.IsBBRExit = true
+			cwnd, _ := strconv.ParseUint(values[0], 10, 32)
+			params.MaxCwndGain = uint32(cwnd)
 		}
 	}
 	return params, nil


### PR DESCRIPTION
This PR makes changes to the `sender` for ndt7 tests to enable both `early_exit` and `bbr_exit` for the same test (or individually, as before). This was, the client can request that the test stop once both conditions are met (I.e., number of bytes sent >= x **and** the congestion window gain >= y).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-test/11)
<!-- Reviewable:end -->
