### PR TITLE
Add ClientMetadata to packet pair/train tests

### DIFF
--- a/api/packet.go
+++ b/api/packet.go
@@ -1,6 +1,10 @@
 package api
 
-import "time"
+import (
+	"time"
+
+	"github.com/m-lab/ndt-server/metadata"
+)
 
 // Packet represents the packet sent for network testing.
 type Packet struct {
@@ -12,9 +16,10 @@ type Packet struct {
 
 // Result represents the result of a packet test.
 type Result struct {
-	Server       string
-	Client       string
-	Measurements []Measurement
+	Server         string
+	Client         string
+	ClientMetadata []metadata.NameValue
+	Measurements   []Measurement
 }
 
 // Received encapsulates the structure received over the network

--- a/cmd/client/pair1/pair1.go
+++ b/cmd/client/pair1/pair1.go
@@ -19,6 +19,7 @@ const (
 
 var (
 	server = flag.String("server", "localhost", "Server address")
+	params = flag.String("params", "", "Client paramerters")
 )
 
 func main() {
@@ -39,7 +40,7 @@ func main() {
 		log.Errorf("Packet pair test failed: %v", err)
 	}
 
-	err = client.SendMeasurements(*server+":9998", datatype, measurements)
+	err = client.SendMeasurements(*server+":9998", datatype, *params, measurements)
 	if err != nil {
 		log.Errorf("Failed to send measurements to server: %v", err)
 	}

--- a/cmd/client/train1/train1.go
+++ b/cmd/client/train1/train1.go
@@ -19,6 +19,7 @@ const (
 
 var (
 	server = flag.String("server", "localhost", "Server address")
+	params = flag.String("params", "", "Client paramerters")
 )
 
 func main() {
@@ -39,7 +40,7 @@ func main() {
 		log.Errorf("Packet train test failed: %v", err)
 	}
 
-	err = client.SendMeasurements(*server+":9998", datatype, measurements)
+	err = client.SendMeasurements(*server+":9998", datatype, *params, measurements)
 	if err != nil {
 		log.Errorf("Failed to send measurements to server: %v", err)
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -48,13 +48,13 @@ func GetDelta(first time.Time, last time.Time) int64 {
 		(last.UnixMicro() - first.UnixMicro())
 }
 
-func SendMeasurements(addr string, datatype string, measurements []api.Measurement) error {
+func SendMeasurements(addr, datatype, params string, measurements []api.Measurement) error {
 	b, err := json.Marshal(measurements)
 	if err != nil {
 		return err
 	}
 
-	url := fmt.Sprintf("http://%s/v0/result?datatype=%s", addr, datatype)
+	url := fmt.Sprintf("http://%s/v0/result?datatype=%s&%s", addr, datatype, params)
 	_, err = http.Post(url, "application/json", bytes.NewBuffer(b))
 	return err
 }


### PR DESCRIPTION
This PR adds a `ClientMetadata` field to the packet pair/train test result containing parameters passed in the client request.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-test/12)
<!-- Reviewable:end -->
