### PR TITLE
Schedule ndt7 and bbr-terminated tests

### DIFF
--- a/Dockerfile.schedule
+++ b/Dockerfile.schedule
@@ -9,5 +9,6 @@ RUN go mod download
 COPY ./ ./
 RUN go build -v ./cmd/client/pair1
 RUN go build -v ./cmd/client/train1
+RUN go build -v ./cmd/client/ndt7
 
 ENTRYPOINT [ "./batch.sh" ]

--- a/batch.sh
+++ b/batch.sh
@@ -1,24 +1,59 @@
 #!/bin/sh
 set -ex
 
-while true; do
-    /packet-test-schedule/train1 -server pt-mlab1-lga0t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/train1 -server pt-mlab1-lga1t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/train1 -server pt-mlab2-lga0t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/train1 -server pt-mlab2-lga1t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/train1 -server pt-mlab3-lga0t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/train1 -server pt-mlab3-lga1t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/train1 -server pt-mlab4-lga0t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/train1 -server pt-mlab4-lga1t.mlab-sandbox.measurement-lab.org
+# TODO: pass-in machine hostname.
+HOSTNAME=$(hostname -f)
 
-    /packet-test-schedule/pair1 -server pt-mlab1-lga0t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/pair1 -server pt-mlab1-lga1t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/pair1 -server pt-mlab2-lga0t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/pair1 -server pt-mlab2-lga1t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/pair1 -server pt-mlab3-lga0t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/pair1 -server pt-mlab3-lga1t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/pair1 -server pt-mlab4-lga0t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/pair1 -server pt-mlab4-lga1t.mlab-sandbox.measurement-lab.org
+while true; do
+    # Packet test.
+    /packet-test-schedule/train1 -server pt-mlab1-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/train1 -server pt-mlab1-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/train1 -server pt-mlab2-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/train1 -server pt-mlab2-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/train1 -server pt-mlab3-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/train1 -server pt-mlab3-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/train1 -server pt-mlab4-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/train1 -server pt-mlab4-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+
+    # Full ndt7 test.
+    /packet-test-schedule/ndt7 -server pt-mlab1-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/ndt7 -server pt-mlab1-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/ndt7 -server pt-mlab2-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/ndt7 -server pt-mlab2-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/ndt7 -server pt-mlab3-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/ndt7 -server pt-mlab3-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/ndt7 -server pt-mlab4-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/ndt7 -server pt-mlab4-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+
+    # BBR-terminated test.
+    /packet-test-schedule/ndt7 -server pt-mlab1-lga0t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&client_hostname=$HOSTNAME"
+    /packet-test-schedule/ndt7 -server pt-mlab1-lga1t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&client_hostname=$HOSTNAME"
+    /packet-test-schedule/ndt7 -server pt-mlab2-lga0t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&client_hostname=$HOSTNAME"
+    /packet-test-schedule/ndt7 -server pt-mlab2-lga1t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&client_hostname=$HOSTNAME"
+    /packet-test-schedule/ndt7 -server pt-mlab3-lga0t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&client_hostname=$HOSTNAME"
+    /packet-test-schedule/ndt7 -server pt-mlab3-lga1t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&client_hostname=$HOSTNAME"
+    /packet-test-schedule/ndt7 -server pt-mlab4-lga0t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&client_hostname=$HOSTNAME"
+    /packet-test-schedule/ndt7 -server pt-mlab4-lga1t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&client_hostname=$HOSTNAME"
+
+    # BBR/100MB-terminated test.
+    /packet-test-schedule/ndt7 -server pt-mlab1-lga0t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=100&client_hostname=$HOSTNAME"
+    /packet-test-schedule/ndt7 -server pt-mlab1-lga1t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=100&client_hostname=$HOSTNAME"
+    /packet-test-schedule/ndt7 -server pt-mlab2-lga0t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=100&client_hostname=$HOSTNAME"
+    /packet-test-schedule/ndt7 -server pt-mlab2-lga1t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=100&client_hostname=$HOSTNAME"
+    /packet-test-schedule/ndt7 -server pt-mlab3-lga0t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=100&client_hostname=$HOSTNAME"
+    /packet-test-schedule/ndt7 -server pt-mlab3-lga1t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=100&client_hostname=$HOSTNAME"
+    /packet-test-schedule/ndt7 -server pt-mlab4-lga0t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=100&client_hostname=$HOSTNAME"
+    /packet-test-schedule/ndt7 -server pt-mlab4-lga1t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=100&client_hostname=$HOSTNAME"
+
+    # BBR/200MB-terminated ndt7 test.
+    /packet-test-schedule/ndt7 -server pt-mlab1-lga0t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=200&client_hostname=$HOSTNAME"
+    /packet-test-schedule/ndt7 -server pt-mlab1-lga1t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=200&client_hostname=$HOSTNAME"
+    /packet-test-schedule/ndt7 -server pt-mlab2-lga0t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=200&client_hostname=$HOSTNAME"
+    /packet-test-schedule/ndt7 -server pt-mlab2-lga1t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=200&client_hostname=$HOSTNAME"
+    /packet-test-schedule/ndt7 -server pt-mlab3-lga0t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=200&client_hostname=$HOSTNAME"
+    /packet-test-schedule/ndt7 -server pt-mlab3-lga1t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=200&client_hostname=$HOSTNAME"
+    /packet-test-schedule/ndt7 -server pt-mlab4-lga0t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=200&client_hostname=$HOSTNAME"
+    /packet-test-schedule/ndt7 -server pt-mlab4-lga1t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=200&client_hostname=$HOSTNAME"
 
     sleep 15m
 done

--- a/batch.sh
+++ b/batch.sh
@@ -1,24 +1,43 @@
 #!/bin/sh
 set -ex
 
-while true; do
-    /packet-test-schedule/train1 -server pt-mlab1-lga0t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/train1 -server pt-mlab1-lga1t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/train1 -server pt-mlab2-lga0t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/train1 -server pt-mlab2-lga1t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/train1 -server pt-mlab3-lga0t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/train1 -server pt-mlab3-lga1t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/train1 -server pt-mlab4-lga0t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/train1 -server pt-mlab4-lga1t.mlab-sandbox.measurement-lab.org
+HOSTNAME=$(hostname -f)
 
-    /packet-test-schedule/pair1 -server pt-mlab1-lga0t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/pair1 -server pt-mlab1-lga1t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/pair1 -server pt-mlab2-lga0t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/pair1 -server pt-mlab2-lga1t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/pair1 -server pt-mlab3-lga0t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/pair1 -server pt-mlab3-lga1t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/pair1 -server pt-mlab4-lga0t.mlab-sandbox.measurement-lab.org
-    /packet-test-schedule/pair1 -server pt-mlab4-lga1t.mlab-sandbox.measurement-lab.org
+while true; do
+    # Packet test.
+    /packet-test-schedule/train1 -server pt-mlab1-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/train1 -server pt-mlab1-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/train1 -server pt-mlab2-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/train1 -server pt-mlab2-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/train1 -server pt-mlab3-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/train1 -server pt-mlab3-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/train1 -server pt-mlab4-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/train1 -server pt-mlab4-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+
+    # Full ndt7 test.
+    /packet-test-schedule/ndt7 -server pt-mlab1-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/ndt7 -server pt-mlab1-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/ndt7 -server pt-mlab2-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/ndt7 -server pt-mlab2-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/ndt7 -server pt-mlab3-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/ndt7 -server pt-mlab3-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/ndt7 -server pt-mlab4-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/ndt7 -server pt-mlab4-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+
+    # BBR-terminated test.
+    /packet-test-schedule/ndt7 -server pt-mlab1-lga0t.mlab-sandbox.measurement-lab.org -params=bbr_exit=512&client_hostname=$HOSTNAME
+    /packet-test-schedule/ndt7 -server pt-mlab1-lga1t.mlab-sandbox.measurement-lab.org -params=bbr_exit=512&client_hostname=$HOSTNAME
+    /packet-test-schedule/ndt7 -server pt-mlab2-lga0t.mlab-sandbox.measurement-lab.org -params=bbr_exit=512&client_hostname=$HOSTNAME
+    /packet-test-schedule/ndt7 -server pt-mlab2-lga1t.mlab-sandbox.measurement-lab.org -params=bbr_exit=512&client_hostname=$HOSTNAME
+    /packet-test-schedule/ndt7 -server pt-mlab3-lga0t.mlab-sandbox.measurement-lab.org -params=bbr_exit=512&client_hostname=$HOSTNAME
+    /packet-test-schedule/ndt7 -server pt-mlab3-lga1t.mlab-sandbox.measurement-lab.org -params=bbr_exit=512&client_hostname=$HOSTNAME
+    /packet-test-schedule/ndt7 -server pt-mlab4-lga0t.mlab-sandbox.measurement-lab.org -params=bbr_exit=512&client_hostname=$HOSTNAME
+    /packet-test-schedule/ndt7 -server pt-mlab4-lga1t.mlab-sandbox.measurement-lab.org -params=bbr_exit=512&client_hostname=$HOSTNAME
+
+    # BBR/100MB-terminated test.
+
+
+    # BBR/200MB-terminated ndt7 test.
 
     sleep 15m
 done

--- a/batch.sh
+++ b/batch.sh
@@ -4,56 +4,22 @@ set -ex
 # TODO: pass-in machine hostname.
 HOSTNAME=$(hostname -f)
 
+server="pt-mlab1-lga0t.mlab-sandbox.measurement-lab.org"
 while true; do
     # Packet test.
-    /packet-test-schedule/train1 -server pt-mlab1-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/train1 -server pt-mlab1-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/train1 -server pt-mlab2-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/train1 -server pt-mlab2-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/train1 -server pt-mlab3-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/train1 -server pt-mlab3-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/train1 -server pt-mlab4-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/train1 -server pt-mlab4-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/train1 -server $server -params=client_hostname=$HOSTNAME
 
     # Full ndt7 test.
-    /packet-test-schedule/ndt7 -server pt-mlab1-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/ndt7 -server pt-mlab1-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/ndt7 -server pt-mlab2-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/ndt7 -server pt-mlab2-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/ndt7 -server pt-mlab3-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/ndt7 -server pt-mlab3-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/ndt7 -server pt-mlab4-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/ndt7 -server pt-mlab4-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/ndt7 -server $server -params=client_hostname=$HOSTNAME
 
     # BBR-terminated test.
-    /packet-test-schedule/ndt7 -server pt-mlab1-lga0t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&client_hostname=$HOSTNAME"
-    /packet-test-schedule/ndt7 -server pt-mlab1-lga1t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&client_hostname=$HOSTNAME"
-    /packet-test-schedule/ndt7 -server pt-mlab2-lga0t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&client_hostname=$HOSTNAME"
-    /packet-test-schedule/ndt7 -server pt-mlab2-lga1t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&client_hostname=$HOSTNAME"
-    /packet-test-schedule/ndt7 -server pt-mlab3-lga0t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&client_hostname=$HOSTNAME"
-    /packet-test-schedule/ndt7 -server pt-mlab3-lga1t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&client_hostname=$HOSTNAME"
-    /packet-test-schedule/ndt7 -server pt-mlab4-lga0t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&client_hostname=$HOSTNAME"
-    /packet-test-schedule/ndt7 -server pt-mlab4-lga1t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&client_hostname=$HOSTNAME"
+    /packet-test-schedule/ndt7 -server $server -params="bbr_exit=512&client_hostname=$HOSTNAME"
 
     # BBR/100MB-terminated test.
-    /packet-test-schedule/ndt7 -server pt-mlab1-lga0t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=100&client_hostname=$HOSTNAME"
-    /packet-test-schedule/ndt7 -server pt-mlab1-lga1t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=100&client_hostname=$HOSTNAME"
-    /packet-test-schedule/ndt7 -server pt-mlab2-lga0t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=100&client_hostname=$HOSTNAME"
-    /packet-test-schedule/ndt7 -server pt-mlab2-lga1t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=100&client_hostname=$HOSTNAME"
-    /packet-test-schedule/ndt7 -server pt-mlab3-lga0t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=100&client_hostname=$HOSTNAME"
-    /packet-test-schedule/ndt7 -server pt-mlab3-lga1t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=100&client_hostname=$HOSTNAME"
-    /packet-test-schedule/ndt7 -server pt-mlab4-lga0t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=100&client_hostname=$HOSTNAME"
-    /packet-test-schedule/ndt7 -server pt-mlab4-lga1t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=100&client_hostname=$HOSTNAME"
+    /packet-test-schedule/ndt7 -server $server -params="bbr_exit=512&early_exit=100&client_hostname=$HOSTNAME"
 
     # BBR/200MB-terminated ndt7 test.
-    /packet-test-schedule/ndt7 -server pt-mlab1-lga0t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=200&client_hostname=$HOSTNAME"
-    /packet-test-schedule/ndt7 -server pt-mlab1-lga1t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=200&client_hostname=$HOSTNAME"
-    /packet-test-schedule/ndt7 -server pt-mlab2-lga0t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=200&client_hostname=$HOSTNAME"
-    /packet-test-schedule/ndt7 -server pt-mlab2-lga1t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=200&client_hostname=$HOSTNAME"
-    /packet-test-schedule/ndt7 -server pt-mlab3-lga0t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=200&client_hostname=$HOSTNAME"
-    /packet-test-schedule/ndt7 -server pt-mlab3-lga1t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=200&client_hostname=$HOSTNAME"
-    /packet-test-schedule/ndt7 -server pt-mlab4-lga0t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=200&client_hostname=$HOSTNAME"
-    /packet-test-schedule/ndt7 -server pt-mlab4-lga1t.mlab-sandbox.measurement-lab.org -params="bbr_exit=512&early_exit=200&client_hostname=$HOSTNAME"
+    /packet-test-schedule/ndt7 -server $server -params="bbr_exit=512&early_exit=200&client_hostname=$HOSTNAME"
 
-    sleep 15m
+    sleep 3h
 done

--- a/batch.sh
+++ b/batch.sh
@@ -1,43 +1,24 @@
 #!/bin/sh
 set -ex
 
-HOSTNAME=$(hostname -f)
-
 while true; do
-    # Packet test.
-    /packet-test-schedule/train1 -server pt-mlab1-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/train1 -server pt-mlab1-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/train1 -server pt-mlab2-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/train1 -server pt-mlab2-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/train1 -server pt-mlab3-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/train1 -server pt-mlab3-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/train1 -server pt-mlab4-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/train1 -server pt-mlab4-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
+    /packet-test-schedule/train1 -server pt-mlab1-lga0t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/train1 -server pt-mlab1-lga1t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/train1 -server pt-mlab2-lga0t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/train1 -server pt-mlab2-lga1t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/train1 -server pt-mlab3-lga0t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/train1 -server pt-mlab3-lga1t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/train1 -server pt-mlab4-lga0t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/train1 -server pt-mlab4-lga1t.mlab-sandbox.measurement-lab.org
 
-    # Full ndt7 test.
-    /packet-test-schedule/ndt7 -server pt-mlab1-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/ndt7 -server pt-mlab1-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/ndt7 -server pt-mlab2-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/ndt7 -server pt-mlab2-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/ndt7 -server pt-mlab3-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/ndt7 -server pt-mlab3-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/ndt7 -server pt-mlab4-lga0t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-    /packet-test-schedule/ndt7 -server pt-mlab4-lga1t.mlab-sandbox.measurement-lab.org -params=client_hostname=$HOSTNAME
-
-    # BBR-terminated test.
-    /packet-test-schedule/ndt7 -server pt-mlab1-lga0t.mlab-sandbox.measurement-lab.org -params=bbr_exit=512&client_hostname=$HOSTNAME
-    /packet-test-schedule/ndt7 -server pt-mlab1-lga1t.mlab-sandbox.measurement-lab.org -params=bbr_exit=512&client_hostname=$HOSTNAME
-    /packet-test-schedule/ndt7 -server pt-mlab2-lga0t.mlab-sandbox.measurement-lab.org -params=bbr_exit=512&client_hostname=$HOSTNAME
-    /packet-test-schedule/ndt7 -server pt-mlab2-lga1t.mlab-sandbox.measurement-lab.org -params=bbr_exit=512&client_hostname=$HOSTNAME
-    /packet-test-schedule/ndt7 -server pt-mlab3-lga0t.mlab-sandbox.measurement-lab.org -params=bbr_exit=512&client_hostname=$HOSTNAME
-    /packet-test-schedule/ndt7 -server pt-mlab3-lga1t.mlab-sandbox.measurement-lab.org -params=bbr_exit=512&client_hostname=$HOSTNAME
-    /packet-test-schedule/ndt7 -server pt-mlab4-lga0t.mlab-sandbox.measurement-lab.org -params=bbr_exit=512&client_hostname=$HOSTNAME
-    /packet-test-schedule/ndt7 -server pt-mlab4-lga1t.mlab-sandbox.measurement-lab.org -params=bbr_exit=512&client_hostname=$HOSTNAME
-
-    # BBR/100MB-terminated test.
-
-
-    # BBR/200MB-terminated ndt7 test.
+    /packet-test-schedule/pair1 -server pt-mlab1-lga0t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/pair1 -server pt-mlab1-lga1t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/pair1 -server pt-mlab2-lga0t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/pair1 -server pt-mlab2-lga1t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/pair1 -server pt-mlab3-lga0t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/pair1 -server pt-mlab3-lga1t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/pair1 -server pt-mlab4-lga0t.mlab-sandbox.measurement-lab.org
+    /packet-test-schedule/pair1 -server pt-mlab4-lga1t.mlab-sandbox.measurement-lab.org
 
     sleep 15m
 done

--- a/cmd/client/ndt7/ndt7.go
+++ b/cmd/client/ndt7/ndt7.go
@@ -29,7 +29,6 @@ func main() {
 	url := fmt.Sprintf("ws://%s:9998/v0/ndt7?%s", *server, *params)
 	conn, _, err := dialer.DialContext(ctx, url, http.Header{})
 	rtx.Must(err, "Dial failed", err)
-	defer conn.Close()
 
 	for {
 		mtype, msg, err := conn.ReadMessage()

--- a/cmd/client/ndt7/ndt7.go
+++ b/cmd/client/ndt7/ndt7.go
@@ -27,9 +27,8 @@ func main() {
 	dialer := websocket.Dialer{}
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(spec.MaxRuntime))
 	url := fmt.Sprintf("ws://%s:9998/v0/ndt7?%s", *server, *params)
-	conn, _, err := dialer.DialContext(ctx, url, http.Header{})
+	conn, _, err := dialer.DialContext(context.Background(), url, http.Header{})
 	rtx.Must(err, "Dial failed", err)
-	defer conn.Close()
 
 	for {
 		mtype, msg, err := conn.ReadMessage()

--- a/cmd/client/ndt7/ndt7.go
+++ b/cmd/client/ndt7/ndt7.go
@@ -29,6 +29,7 @@ func main() {
 	url := fmt.Sprintf("ws://%s:9998/v0/ndt7?%s", *server, *params)
 	conn, _, err := dialer.DialContext(ctx, url, http.Header{})
 	rtx.Must(err, "Dial failed", err)
+	defer conn.Close()
 
 	for {
 		mtype, msg, err := conn.ReadMessage()

--- a/cmd/client/ndt7/ndt7.go
+++ b/cmd/client/ndt7/ndt7.go
@@ -6,12 +6,14 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/apex/log"
 
 	"github.com/gorilla/websocket"
 	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/ndt-server/ndt7/model"
+	"github.com/m-lab/ndt-server/ndt7/spec"
 )
 
 var (
@@ -23,7 +25,7 @@ func main() {
 	flag.Parse()
 
 	dialer := websocket.Dialer{}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(spec.MaxRuntime))
 	url := fmt.Sprintf("ws://%s:9998/v0/ndt7?%s", *server, *params)
 	conn, _, err := dialer.DialContext(ctx, url, http.Header{})
 	rtx.Must(err, "Dial failed", err)

--- a/handler/ndt7.go
+++ b/handler/ndt7.go
@@ -39,6 +39,7 @@ func (c *Client) NDT7Download(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	defer conn.Close()
 
 	// Get client parameters (e.g., early_exit, bbr_exit).
 	params, err := getParams(req.URL.Query())

--- a/handler/ndt7.go
+++ b/handler/ndt7.go
@@ -39,7 +39,6 @@ func (c *Client) NDT7Download(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	defer conn.Close()
 
 	// Get client parameters (e.g., early_exit, bbr_exit).
 	params, err := getParams(req.URL.Query())

--- a/pkg/ndt7/sender/sender.go
+++ b/pkg/ndt7/sender/sender.go
@@ -83,9 +83,11 @@ func Start(ctx context.Context, conn *websocket.Conn, data *model.ArchivalData, 
 			}
 
 			if m.TCPInfo != nil {
-				if isEarlyExitDone(params, m) && isBBRExitDone(params, m) {
-					closer.StartClosing(conn)
-					return nil
+				if params.MaxBytes > 0 && params.MaxCwndGain > 0 {
+					if m.TCPInfo.BytesAcked >= params.MaxBytes && m.BBRInfo.CwndGain >= params.MaxCwndGain {
+						closer.StartClosing(conn)
+						return nil
+					}
 				} else if isEarlyExitDone(params, m) {
 					closer.StartClosing(conn)
 					return nil


### PR DESCRIPTION
This PR adds ndt7 and bbr-terminated tests to the batch scheduling script (along with packet train). 

There are also a couple changes to the client/server code to make that possible.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-test/14)
<!-- Reviewable:end -->
