### PR TITLE
Rename bbr_exit to max_cwnd_gain

### DIFF
--- a/handler/ndt7.go
+++ b/handler/ndt7.go
@@ -40,7 +40,7 @@ func (c *Client) NDT7Download(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// Get client parameters (e.g., early_exit, bbr_exit).
+	// Get client parameters.
 	params, err := getParams(req.URL.Query())
 
 	// Get data.
@@ -89,12 +89,13 @@ func getData(conn *websocket.Conn) (*model.ArchivalData, error) {
 func getParams(values url.Values) (*sender.Params, error) {
 	params := &sender.Params{}
 	for name, values := range values {
+		value := values[0]
 		switch name {
 		case static.EarlyExitParameterName:
-			bytes, _ := strconv.ParseInt(values[0], 10, 64)
-			params.MaxBytes = bytes * 1000000 // Conver MB to bytes.
-		case static.BBRExitParameterName:
-			cwnd, _ := strconv.ParseUint(values[0], 10, 32)
+			bytes, _ := strconv.ParseInt(value, 10, 64)
+			params.MaxBytes = bytes * 1000000 // Convert MB to bytes.
+		case static.MaxCwndGainParameterName:
+			cwnd, _ := strconv.ParseUint(value, 10, 32)
 			params.MaxCwndGain = uint32(cwnd)
 		}
 	}

--- a/handler/ndt7.go
+++ b/handler/ndt7.go
@@ -86,9 +86,9 @@ func getData(conn *websocket.Conn) (*model.ArchivalData, error) {
 	return data, nil
 }
 
-func getParams(values url.Values) (*sender.Params, error) {
+func getParams(urlValues url.Values) (*sender.Params, error) {
 	params := &sender.Params{}
-	for name, values := range values {
+	for name, values := range urlValues {
 		value := values[0]
 		switch name {
 		case static.EarlyExitParameterName:

--- a/static/spec.go
+++ b/static/spec.go
@@ -13,5 +13,7 @@ const (
 	TrainDelay             = 1 * time.Second
 	TrainLength            = 30
 	EarlyExitParameterName = "early_exit"
-	BBRExitParameterName   = "bbr_exit"
+	// MaxCwndGainParameterName is the name of a client parameter whose value indicates a BBR
+	// congestion window (cwnd) gain after which the test should exit.
+	MaxCwndGainParameterName = "max_cwnd_gain"
 )


### PR DESCRIPTION
This PR renames the `bbr_exit` parameter name to `max_cwnd_gain`. If, in the future, we want to use other BBR variables to guide test termination, `bbr_exit` would have been too generic.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-test/15)
<!-- Reviewable:end -->
