### PR TITLE
Add testing for the ndt7 download handler

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/ndt-server/ndt7/listener"
 	"github.com/m-lab/packet-test/handler"
+	"github.com/m-lab/packet-test/static"
 )
 
 var (
@@ -33,7 +34,7 @@ func main() {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v0/result", http.HandlerFunc(h.HandleResult))
-	mux.HandleFunc("/v0/ndt7", http.HandlerFunc(h.NDT7Download))
+	mux.HandleFunc(static.NDT7DownloadURLPath, http.HandlerFunc(h.NDT7Download))
 	srv := &http.Server{
 		Addr:    ":9998",
 		Handler: mux,

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -20,14 +20,15 @@ import (
 
 // Client handles requests for packet tests.
 type Client struct {
-	dataDir  string
+	// DataDir is the directory where measurement results are saved.
+	DataDir  string
 	hostname string
 }
 
 // New returns a new instance of *Client.
 func New(dataDir string, hostname string) *Client {
 	return &Client{
-		dataDir:  dataDir,
+		DataDir:  dataDir,
 		hostname: hostname,
 	}
 }
@@ -86,7 +87,7 @@ func (c *Client) HandleResult(rw http.ResponseWriter, req *http.Request) {
 
 func (c *Client) writeMeasurements(datatype string, data interface{}) error {
 	t := time.Now().UTC()
-	dir := path.Join(c.dataDir, datatype, t.Format(timex.YYYYMMDDWithSlash))
+	dir := path.Join(c.DataDir, datatype, t.Format(timex.YYYYMMDDWithSlash))
 	err := os.MkdirAll(dir, 0755)
 	if err != nil {
 		return err

--- a/handler/ndt7_test.go
+++ b/handler/ndt7_test.go
@@ -1,0 +1,62 @@
+package handler_test
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/m-lab/go/testingx"
+	"github.com/m-lab/ndt-server/ndt7/spec"
+	"github.com/m-lab/packet-test/static"
+	"github.com/m-lab/packet-test/testdata"
+)
+
+func TestClient_NDT7Download(t *testing.T) {
+	// Start the server.
+	h, srv := testdata.NewNDT7Server(t)
+	defer os.RemoveAll(h.DataDir)
+
+	// Run a download test.
+	URL, _ := url.Parse(srv.URL)
+	URL.Scheme = "ws"
+	URL.Path = static.NDT7DownloadURLPath
+	headers := http.Header{}
+	headers.Add("Sec-WebSocket-Protocol", spec.SecWebSocketProtocol)
+	headers.Add("User-Agent", "fake-user-agent")
+	ctx := context.Background()
+	dialer := websocket.Dialer{HandshakeTimeout: 10 * time.Second}
+	conn, _, err := dialer.DialContext(ctx, URL.String(), headers)
+	testingx.Must(t, err, "failed to dial websocket ndt7 test")
+	err = simpleDownload(ctx, t, conn)
+	if err != nil && !websocket.IsCloseError(err, websocket.CloseNormalClosure) {
+		testingx.Must(t, err, "failed to download")
+	}
+
+	// Allow the server time to save the file. The client may stop before the server does.
+	time.Sleep(10 * time.Second)
+	// Verify a file was saved.
+	m, err := filepath.Glob(h.DataDir + "/ndt7/*/*/*/*")
+	testingx.Must(t, err, "failed to glob datadir: %s", h.DataDir)
+	if len(m) == 0 {
+		t.Errorf("no result files found")
+	}
+}
+
+// WARNING: this is not a reference client.
+func simpleDownload(ctx context.Context, t *testing.T, conn *websocket.Conn) error {
+	defer conn.Close()
+	conn.SetReadLimit(spec.MaxMessageSize)
+	err := conn.SetReadDeadline(time.Now().Add(spec.MaxRuntime))
+	testingx.Must(t, err, "failed to set read deadline")
+	_, _, err = conn.ReadMessage()
+	if err != nil {
+		return err
+	}
+	// We only read one message, so this is an early close.
+	return conn.Close()
+}

--- a/static/spec.go
+++ b/static/spec.go
@@ -12,6 +12,7 @@ const (
 	TrainCount             = 10
 	TrainDelay             = 1 * time.Second
 	TrainLength            = 30
+	NDT7DownloadURLPath    = "/v0/ndt7/download"
 	EarlyExitParameterName = "early_exit"
 	// MaxCwndGainParameterName is the name of a client parameter whose value indicates a BBR
 	// congestion window (cwnd) gain after which the test should exit.

--- a/testdata/ndt7.go
+++ b/testdata/ndt7.go
@@ -1,0 +1,32 @@
+package testdata
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/m-lab/go/testingx"
+	"github.com/m-lab/ndt-server/netx"
+	"github.com/m-lab/packet-test/handler"
+	"github.com/m-lab/packet-test/static"
+)
+
+// NewNDT7Server creates a local httptest server for unit tests.
+func NewNDT7Server(t *testing.T) (*handler.Client, *httptest.Server) {
+	dir := t.TempDir()
+
+	handler := handler.New(dir, "fake-hostname")
+	ndt7Mux := http.NewServeMux()
+	ndt7Mux.Handle(static.NDT7DownloadURLPath, http.HandlerFunc(handler.NDT7Download))
+
+	// Create unstarted so we can setup a custom netx.Listener.
+	srv := httptest.NewUnstartedServer(ndt7Mux)
+	listener, err := net.Listen("tcp", ":0")
+	testingx.Must(t, err, "failed to allocate a listening tcp socket")
+	srv.Listener = netx.NewListener(listener.(*net.TCPListener))
+	// Now that the test server has our custom listener, start it.
+	srv.Start()
+
+	return handler, srv
+}


### PR DESCRIPTION
This PR adds testing for the ndt7 download handler.

I will add CI in a future PR. For now, just a Docker image gets pushed to [docker hub](https://hub.docker.com/repository/docker/measurementlab/packet-test/general) with the latest commit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-test/16)
<!-- Reviewable:end -->
