### PR TITLE
Remove flaky test

### DIFF
--- a/handler/ndt7_test.go
+++ b/handler/ndt7_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -35,15 +34,6 @@ func TestClient_NDT7Download(t *testing.T) {
 	err = simpleDownload(ctx, t, conn)
 	if err != nil && !websocket.IsCloseError(err, websocket.CloseNormalClosure) {
 		testingx.Must(t, err, "failed to download")
-	}
-
-	// Allow the server time to save the file. The client may stop before the server does.
-	time.Sleep(10 * time.Second)
-	// Verify a file was saved.
-	m, err := filepath.Glob(h.DataDir + "/ndt7/*/*/*/*")
-	testingx.Must(t, err, "failed to glob datadir: %s", h.DataDir)
-	if len(m) == 0 {
-		t.Errorf("no result files found")
 	}
 }
 


### PR DESCRIPTION
This PR removes a file check from the handler tests, leaving the websocket close check. The file check was flaky because sometimes the server does not have enough time to save the file before the test checks.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-test/19)
<!-- Reviewable:end -->
