### PR TITLE
Add ElapsedTime termination

### DIFF
--- a/handler/ndt7.go
+++ b/handler/ndt7.go
@@ -97,6 +97,9 @@ func getParams(urlValues url.Values) (*sender.Params, error) {
 		case static.MaxCwndGainParameterName:
 			cwnd, _ := strconv.ParseUint(value, 10, 32)
 			params.MaxCwndGain = uint32(cwnd)
+		case static.MaxElapsedTimeParameterName:
+			time, _ := strconv.ParseInt(value, 10, 64)
+			params.MaxElapsedTime = time
 		}
 	}
 	return params, nil

--- a/pkg/ndt7/sender/sender_test.go
+++ b/pkg/ndt7/sender/sender_test.go
@@ -1,0 +1,110 @@
+package sender
+
+import (
+	"testing"
+
+	"github.com/m-lab/ndt-server/ndt7/model"
+	"github.com/m-lab/tcp-info/inetdiag"
+	"github.com/m-lab/tcp-info/tcp"
+)
+
+func Test_terminateTest(t *testing.T) {
+	tests := []struct {
+		name string
+		p    *Params
+		m    model.Measurement
+		want bool
+	}{
+		{
+			name: "max_cwnd_gain and max_elapsed_time",
+			p: &Params{
+				MaxCwndGain:    10,
+				MaxElapsedTime: 10,
+			},
+			m: model.Measurement{
+				BBRInfo: &model.BBRInfo{
+					BBRInfo: inetdiag.BBRInfo{
+						CwndGain: 10,
+					},
+				},
+				TCPInfo: &model.TCPInfo{
+					ElapsedTime: 10,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "max_cwnd_gain and early_exit",
+			p: &Params{
+				MaxCwndGain: 10,
+				MaxBytes:    10,
+			},
+			m: model.Measurement{
+				BBRInfo: &model.BBRInfo{
+					BBRInfo: inetdiag.BBRInfo{
+						CwndGain: 10,
+					},
+				},
+				TCPInfo: &model.TCPInfo{
+					LinuxTCPInfo: tcp.LinuxTCPInfo{
+						BytesAcked: 10,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "max_cwnd_gain only",
+			p: &Params{
+				MaxCwndGain: 10,
+			},
+			m: model.Measurement{
+				BBRInfo: &model.BBRInfo{
+					BBRInfo: inetdiag.BBRInfo{
+						CwndGain: 10,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "max_elapsed_time only",
+			p: &Params{
+				MaxElapsedTime: 10,
+			},
+			m: model.Measurement{
+				TCPInfo: &model.TCPInfo{
+					ElapsedTime: 10,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "early_exit only",
+			p: &Params{
+				MaxBytes: 10,
+			},
+			m: model.Measurement{
+				TCPInfo: &model.TCPInfo{
+					LinuxTCPInfo: tcp.LinuxTCPInfo{
+						BytesAcked: 10,
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "no limit",
+			p:    &Params{},
+			m:    model.Measurement{},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := terminateTest(tt.p, tt.m); got != tt.want {
+				t.Errorf("terminateTest() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/static/spec.go
+++ b/static/spec.go
@@ -17,4 +17,7 @@ const (
 	// MaxCwndGainParameterName is the name of a client parameter whose value indicates a BBR
 	// congestion window (cwnd) gain after which the test should exit.
 	MaxCwndGainParameterName = "max_cwnd_gain"
+	// MaxElapsedTime is the name of the name of a client parameter whose values indicates the
+	// number of seconds after which the test should exit.
+	MaxElapsedTimeParameterName = "max_elapsed_time"
 )


### PR DESCRIPTION
This PR adds a client parameter to terminate the test based on TCPInfo's `ElapsedTime` (seconds). 

It also supports combinations of early termination parameters (e.g., `max_cwnd_gain` & `max_elapsed_time`) to test scenarios where both conditions are fulfilled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-test/20)
<!-- Reviewable:end -->
