### PR TITLE
Enable immediate test termination

### DIFF
--- a/handler/ndt7.go
+++ b/handler/ndt7.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/apex/log"
@@ -90,6 +91,7 @@ func getParams(urlValues url.Values) (*sender.Params, error) {
 	params := &sender.Params{}
 	for name, values := range urlValues {
 		value := values[0]
+		name = strings.TrimPrefix(name, "client_")
 		switch name {
 		case static.EarlyExitParameterName:
 			bytes, _ := strconv.ParseInt(value, 10, 64)

--- a/handler/ndt7.go
+++ b/handler/ndt7.go
@@ -100,6 +100,8 @@ func getParams(urlValues url.Values) (*sender.Params, error) {
 		case static.MaxElapsedTimeParameterName:
 			time, _ := strconv.ParseInt(value, 10, 64)
 			params.MaxElapsedTime = time
+		case static.ImmediateExitParameterName:
+			params.ImmediateExit, _ = strconv.ParseBool(value)
 		}
 	}
 	return params, nil

--- a/pkg/ndt7/measurer/measurer.go
+++ b/pkg/ndt7/measurer/measurer.go
@@ -1,3 +1,5 @@
+// Package measurer collects metrics from a socket connection
+// and returns them for consumption.
 package measurer
 
 import (
@@ -6,40 +8,113 @@ import (
 
 	"github.com/apex/log"
 	"github.com/gorilla/websocket"
-	"github.com/m-lab/ndt-server/ndt7/measurer"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/m-lab/go/memoryless"
+	"github.com/m-lab/ndt-server/logging"
 	"github.com/m-lab/ndt-server/ndt7/model"
+	"github.com/m-lab/ndt-server/ndt7/spec"
 	"github.com/m-lab/ndt-server/netx"
 )
 
-// Monitor measures network metrics.
-type Monitor struct {
-	*measurer.Measurer
+var (
+	BBREnabled = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ndt7_measurer_bbr_enabled_total",
+			Help: "A counter of every attempt to enable bbr.",
+		},
+		[]string{"status", "error"},
+	)
+)
+
+// Measurer performs measurements
+type Measurer struct {
 	conn     *websocket.Conn
-	connInfo *model.ConnectionInfo
+	uuid     string
+	ticker   *memoryless.Ticker
 	start    time.Time
+	connInfo *model.ConnectionInfo
 }
 
-// New creates a new Monitor instance.
-func New(conn *websocket.Conn, UUID string) *Monitor {
-	return &Monitor{
-		Measurer: measurer.New(conn, UUID),
-		conn:     conn,
-		connInfo: &model.ConnectionInfo{
-			Client: conn.RemoteAddr().String(),
-			Server: conn.LocalAddr().String(),
-			UUID:   UUID,
-		},
+// New creates a new measurer instance
+func New(conn *websocket.Conn, UUID string) *Measurer {
+	return &Measurer{
+		conn: conn,
+		uuid: UUID,
 	}
 }
 
-// Start runs the measurement loop and records the start time.
-func (m *Monitor) Start(ctx context.Context, timeout time.Duration) <-chan model.Measurement {
+func (m *Measurer) getSocketAndPossiblyEnableBBR() (netx.ConnInfo, error) {
+	ci := netx.ToConnInfo(m.conn.UnderlyingConn())
+	err := ci.EnableBBR()
+	success := "true"
+	errstr := ""
+	if err != nil {
+		success = "false"
+		errstr = err.Error()
+		uuid, _ := ci.GetUUID() // to log error with uuid.
+		logging.Logger.WithError(err).Warn("Cannot enable BBR: " + uuid)
+		// FALLTHROUGH
+	}
+	BBREnabled.WithLabelValues(success, errstr).Inc()
+	return ci, nil
+}
+
+func measure(measurement *model.Measurement, ci netx.ConnInfo, elapsed time.Duration) {
+	// Implementation note: we always want to sample BBR before TCPInfo so we
+	// will know from TCPInfo if the connection has been closed.
+	t := int64(elapsed / time.Microsecond)
+	bbrinfo, tcpInfo, err := ci.ReadInfo()
+	if err == nil {
+		measurement.BBRInfo = &model.BBRInfo{
+			BBRInfo:     bbrinfo,
+			ElapsedTime: t,
+		}
+		measurement.TCPInfo = &model.TCPInfo{
+			LinuxTCPInfo: tcpInfo,
+			ElapsedTime:  t,
+		}
+	}
+}
+
+func (m *Measurer) loop(ctx context.Context, timeout time.Duration, dst chan<- model.Measurement) {
+	logging.Logger.Debug("measurer: start")
+	defer logging.Logger.Debug("measurer: stop")
+	defer close(dst)
+	measurerctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	_, err := m.getSocketAndPossiblyEnableBBR()
+	if err != nil {
+		logging.Logger.WithError(err).Warn("getSocketAndPossiblyEnableBBR failed")
+		return
+	}
 	m.start = time.Now()
-	return m.Measurer.Start(ctx, timeout)
+	m.connInfo = &model.ConnectionInfo{
+		Client: m.conn.RemoteAddr().String(),
+		Server: m.conn.LocalAddr().String(),
+		UUID:   m.uuid,
+	}
+	// Implementation note: the ticker will close its output channel
+	// after the controlling context is expired.
+	ticker, err := memoryless.NewTicker(measurerctx, memoryless.Config{
+		Min:      spec.MinPoissonSamplingInterval,
+		Expected: spec.AveragePoissonSamplingInterval,
+		Max:      spec.MaxPoissonSamplingInterval,
+	})
+	if err != nil {
+		logging.Logger.WithError(err).Warn("memoryless.NewTicker failed")
+		return
+	}
+	m.ticker = ticker
+	for range ticker.C {
+		measurement, _ := m.GetMeasurement()
+		dst <- measurement // Liveness: this is blocking
+	}
 }
 
 // GetMeasurement retrieves the latest measurement snapshot.
-func (m *Monitor) GetMeasurement() (model.Measurement, error) {
+func (m *Measurer) GetMeasurement() (model.Measurement, error) {
 	t := int64(time.Now().Sub(m.start) / time.Microsecond)
 	ci := netx.ToConnInfo(m.conn.UnderlyingConn())
 	bbr, tcp, err := ci.ReadInfo()
@@ -59,4 +134,29 @@ func (m *Monitor) GetMeasurement() (model.Measurement, error) {
 			ElapsedTime:  t,
 		},
 	}, nil
+}
+
+// Start runs the measurement loop in a background goroutine and emits
+// the measurements on the returned channel.
+//
+// Liveness guarantee: the measurer will always terminate after
+// the given timeout, provided that the consumer continues reading from the
+// returned channel. Measurer may be stopped early by canceling ctx, or by
+// calling Stop.
+func (m *Measurer) Start(ctx context.Context, timeout time.Duration) <-chan model.Measurement {
+	dst := make(chan model.Measurement)
+	go m.loop(ctx, timeout, dst)
+	return dst
+}
+
+// Stop ends the measurements and drains the measurement channel. Stop
+// guarantees that the measurement goroutine completes by draining the
+// measurement channel. Users that call Start should also call Stop.
+func (m *Measurer) Stop(src <-chan model.Measurement) {
+	if m.ticker != nil {
+		m.ticker.Stop()
+	}
+	for range src {
+		// make sure we drain the channel, so the measurement loop can exit.
+	}
 }

--- a/pkg/ndt7/measurer/measurer.go
+++ b/pkg/ndt7/measurer/measurer.go
@@ -1,0 +1,62 @@
+package measurer
+
+import (
+	"context"
+	"time"
+
+	"github.com/apex/log"
+	"github.com/gorilla/websocket"
+	"github.com/m-lab/ndt-server/ndt7/measurer"
+	"github.com/m-lab/ndt-server/ndt7/model"
+	"github.com/m-lab/ndt-server/netx"
+)
+
+// Monitor measures network metrics.
+type Monitor struct {
+	*measurer.Measurer
+	conn     *websocket.Conn
+	connInfo *model.ConnectionInfo
+	start    time.Time
+}
+
+// New creates a new Monitor instance.
+func New(conn *websocket.Conn, UUID string) *Monitor {
+	return &Monitor{
+		Measurer: measurer.New(conn, UUID),
+		conn:     conn,
+		connInfo: &model.ConnectionInfo{
+			Client: conn.RemoteAddr().String(),
+			Server: conn.LocalAddr().String(),
+			UUID:   UUID,
+		},
+	}
+}
+
+// Start runs the measurement loop and records the start time.
+func (m *Monitor) Start(ctx context.Context, timeout time.Duration) <-chan model.Measurement {
+	m.start = time.Now()
+	return m.Measurer.Start(ctx, timeout)
+}
+
+// GetMeasurement retrieves the latest measurement snapshot.
+func (m *Monitor) GetMeasurement() (model.Measurement, error) {
+	t := int64(time.Now().Sub(m.start) / time.Microsecond)
+	ci := netx.ToConnInfo(m.conn.UnderlyingConn())
+	bbr, tcp, err := ci.ReadInfo()
+	if err != nil {
+		log.Errorf("measurer: ReadInfo failed", err)
+		return model.Measurement{}, err
+	}
+
+	return model.Measurement{
+		ConnectionInfo: m.connInfo,
+		BBRInfo: &model.BBRInfo{
+			BBRInfo:     bbr,
+			ElapsedTime: t,
+		},
+		TCPInfo: &model.TCPInfo{
+			LinuxTCPInfo: tcp,
+			ElapsedTime:  t,
+		},
+	}, nil
+}

--- a/pkg/ndt7/sender/sender.go
+++ b/pkg/ndt7/sender/sender.go
@@ -148,7 +148,7 @@ func Start(ctx context.Context, conn *websocket.Conn, data *model.ArchivalData, 
 	}
 }
 
-func terminateImmediately(p *Params, mr *measurer.Monitor, conn *websocket.Conn, data *model.ArchivalData) bool {
+func terminateImmediately(p *Params, mr *measurer.Measurer, conn *websocket.Conn, data *model.ArchivalData) bool {
 	if !p.ImmediateExit {
 		return false
 	}

--- a/static/spec.go
+++ b/static/spec.go
@@ -13,11 +13,15 @@ const (
 	TrainDelay             = 1 * time.Second
 	TrainLength            = 30
 	NDT7DownloadURLPath    = "/v0/ndt7/download"
-	EarlyExitParameterName = "early_exit"
+	EarlyExitParameterName = "client_early_exit"
 	// MaxCwndGainParameterName is the name of a client parameter whose value indicates a BBR
 	// congestion window (cwnd) gain after which the test should exit.
-	MaxCwndGainParameterName = "max_cwnd_gain"
-	// MaxElapsedTime is the name of the name of a client parameter whose values indicates the
+	MaxCwndGainParameterName = "client_max_cwnd_gain"
+	// MaxElapsedTime is the name of a client parameter whose values indicates the
 	// number of seconds after which the test should exit.
-	MaxElapsedTimeParameterName = "max_elapsed_time"
+	MaxElapsedTimeParameterName = "client_max_elapsed_time"
+	// ImmediateExitParameterName is the name of the parameter to indicate that the termination
+	// behavior of the test should be immediate, instead of waiting for snapshots to be
+	// taken.
+	ImmediateExitParameterName = "client_immediate_exit"
 )

--- a/static/spec.go
+++ b/static/spec.go
@@ -13,15 +13,15 @@ const (
 	TrainDelay             = 1 * time.Second
 	TrainLength            = 30
 	NDT7DownloadURLPath    = "/v0/ndt7/download"
-	EarlyExitParameterName = "client_early_exit"
+	EarlyExitParameterName = "early_exit"
 	// MaxCwndGainParameterName is the name of a client parameter whose value indicates a BBR
 	// congestion window (cwnd) gain after which the test should exit.
-	MaxCwndGainParameterName = "client_max_cwnd_gain"
+	MaxCwndGainParameterName = "max_cwnd_gain"
 	// MaxElapsedTime is the name of a client parameter whose values indicates the
 	// number of seconds after which the test should exit.
-	MaxElapsedTimeParameterName = "client_max_elapsed_time"
+	MaxElapsedTimeParameterName = "max_elapsed_time"
 	// ImmediateExitParameterName is the name of the parameter to indicate that the termination
-	// behavior of the test should be immediate, instead of waiting for snapshots to be
-	// taken.
-	ImmediateExitParameterName = "client_immediate_exit"
+	// behavior of the test should be immediate, instead of waiting for TCPInfo and BBRInfo
+	// snapshots to be emitted.
+	ImmediateExitParameterName = "immediate_exit"
 )


### PR DESCRIPTION
This PR adds a client parameter called "immediate_exit" to enable test termination as the message sender loop executes, instead of having to wait for the measurer to emit `TCPInfo` and `BBRInfo` snapshots.

It also adds support for client parameters with the "client_" prefix, which are always forwarded by the Locate.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-test/23)
<!-- Reviewable:end -->
