### PR TITLE
Increase snapshot frequency

### DIFF
--- a/pkg/ndt7/measurer/measurer.go
+++ b/pkg/ndt7/measurer/measurer.go
@@ -14,8 +14,8 @@ import (
 	"github.com/m-lab/go/memoryless"
 	"github.com/m-lab/ndt-server/logging"
 	"github.com/m-lab/ndt-server/ndt7/model"
-	"github.com/m-lab/ndt-server/ndt7/spec"
 	"github.com/m-lab/ndt-server/netx"
+	"github.com/m-lab/packet-test/static"
 )
 
 var (
@@ -98,9 +98,9 @@ func (m *Measurer) loop(ctx context.Context, timeout time.Duration, dst chan<- m
 	// Implementation note: the ticker will close its output channel
 	// after the controlling context is expired.
 	ticker, err := memoryless.NewTicker(measurerctx, memoryless.Config{
-		Min:      spec.MinPoissonSamplingInterval,
-		Expected: spec.AveragePoissonSamplingInterval,
-		Max:      spec.MaxPoissonSamplingInterval,
+		Min:      static.MinPoissonSamplingInterval,
+		Expected: static.AveragePoissonSamplingInterval,
+		Max:      static.MaxPoissonSamplingInterval,
 	})
 	if err != nil {
 		logging.Logger.WithError(err).Warn("memoryless.NewTicker failed")

--- a/static/spec.go
+++ b/static/spec.go
@@ -24,4 +24,18 @@ const (
 	// behavior of the test should be immediate, instead of waiting for TCPInfo and BBRInfo
 	// snapshots to be emitted.
 	ImmediateExitParameterName = "immediate_exit"
+
+	// MinPoissonSamplingInterval is the min acceptable time that we want
+	// the lambda distribution to return. Smaller values will be clamped
+	// to be this value instead.
+	MinPoissonSamplingInterval = 25 * time.Millisecond
+
+	// AveragePoissonSamplingInterval is the average of a lambda distribution
+	// used to decide when to perform next measurement.
+	AveragePoissonSamplingInterval = 100 * time.Millisecond
+
+	// MaxPoissonSamplingInterval is the max acceptable time that we want
+	// the lambda distribution to return. Bigger values will be clamped
+	// to be this value instead.
+	MaxPoissonSamplingInterval = 250 * time.Millisecond
 )


### PR DESCRIPTION
This PR increases the `TCPInfo`/`BBRInfo` snapshot sampling interval from Min: 25 ms, Avg: 250 ms, Max: 625 ms to Min: 25 ms, Avg: 100 ms, Max: 250 ms. This will allow for more granular analysis of the snapshots.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-test/24)
<!-- Reviewable:end -->
