### PR TITLE
Parse `max_elapsed_time` as microseconds

### DIFF
--- a/handler/ndt7_test.go
+++ b/handler/ndt7_test.go
@@ -5,12 +5,15 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/m-lab/go/testingx"
 	"github.com/m-lab/ndt-server/ndt7/spec"
+	"github.com/m-lab/packet-test/handler"
+	"github.com/m-lab/packet-test/pkg/ndt7/sender"
 	"github.com/m-lab/packet-test/static"
 	"github.com/m-lab/packet-test/testdata"
 )
@@ -49,4 +52,77 @@ func simpleDownload(ctx context.Context, t *testing.T, conn *websocket.Conn) err
 	}
 	// We only read one message, so this is an early close.
 	return conn.Close()
+}
+
+func Test_getParams(t *testing.T) {
+	type args struct {
+		urlValues url.Values
+	}
+	tests := []struct {
+		name    string
+		vals    url.Values
+		want    *sender.Params
+		wantErr bool
+	}{
+		{
+			name: static.EarlyExitParameterName,
+			vals: url.Values{
+				static.EarlyExitParameterName: []string{"10"}, // 10 MB.
+			},
+			want: &sender.Params{
+				MaxBytes: 10000000, // 10000000 Bytes.
+			},
+			wantErr: false,
+		},
+		{
+			name: static.MaxCwndGainParameterName,
+			vals: url.Values{
+				static.MaxCwndGainParameterName: []string{"512"},
+			},
+			want: &sender.Params{
+				MaxCwndGain: 512,
+			},
+			wantErr: false,
+		},
+		{
+			name: static.MaxElapsedTimeParameterName,
+			vals: url.Values{
+				static.MaxElapsedTimeParameterName: []string{"5"}, // 5 seconds.
+			},
+			want: &sender.Params{
+				MaxElapsedTime: 5000000, // 5000000 microseconds.
+			},
+			wantErr: false,
+		},
+		{
+			name: static.ImmediateExitParameterName,
+			vals: url.Values{
+				static.ImmediateExitParameterName: []string{"true"},
+			},
+			want: &sender.Params{
+				ImmediateExit: true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "error",
+			vals: url.Values{
+				static.EarlyExitParameterName: []string{"foo"},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := handler.GetParams(tt.vals)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("handler.GetParams() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("handler.GetParams() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/pkg/ndt7/sender/sender.go
+++ b/pkg/ndt7/sender/sender.go
@@ -16,8 +16,8 @@ import (
 
 // Params defines the parameters for the sender to end the test early.
 type Params struct {
-	MaxBytes       int64  // TCPInfo.BytesAcked is of type int64.
-	MaxElapsedTime int64  // TCPInfo.ElapsedTime is of type int64.
+	MaxBytes       int64  // TCPInfo.BytesAcked is of type int64 (bytes).
+	MaxElapsedTime int64  // TCPInfo.ElapsedTime is of type int64 (microseconds).
 	MaxCwndGain    uint32 // BBRInfo.CwndGain is of type uint32.
 	ImmediateExit  bool
 }
@@ -175,7 +175,7 @@ func terminateTest(p *Params, m model.Measurement) bool {
 	switch {
 	case p.isMaxCwndGainLimit() && p.isMaxElapsedTimeLimit():
 		if p.isMaxCwndGainDone(m) && p.isMaxElapsedTimeDone(m) {
-			log.Infof("sender: terminating test after %d CwndGain and %d ElapsedTime (s)", m.BBRInfo.CwndGain, m.TCPInfo.ElapsedTime)
+			log.Infof("sender: terminating test after %d CwndGain and %d ElapsedTime (µs)", m.BBRInfo.CwndGain, m.TCPInfo.ElapsedTime)
 			return true
 		}
 	case p.isMaxCwndGainLimit() && p.isEarlyExitLimit():
@@ -190,7 +190,7 @@ func terminateTest(p *Params, m model.Measurement) bool {
 		log.Infof("sender: terminating test after %d BytesAcked", m.TCPInfo.BytesAcked)
 		return true
 	case p.isMaxElapsedTimeLimit() && p.isMaxElapsedTimeDone(m):
-		log.Infof("sender: terminating test after %d ElapsedTime (s)", m.TCPInfo.ElapsedTime)
+		log.Infof("sender: terminating test after %d ElapsedTime (µs)", m.TCPInfo.ElapsedTime)
 		return true
 	}
 


### PR DESCRIPTION
This PR fixes the parsing of the `max_elapsed_time` client parameter by converting the result to microseconds (`TCPInfo.ElapsedTime` is in microseconds). 

It also adds testing and error checking for the parameters.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/packet-test/25)
<!-- Reviewable:end -->
